### PR TITLE
update DESCRIPTION to list dependency R >= 3.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(person("Oleg", "Lugovoy", email = "olugovoy@gmail.com",
 URL: https://github.com/olugovoy/energyRt
 BugReports: https://github.com/olugovoy/energyRt/issues
 Description: Energy Technology Modeling Toolbox
-Depends: sp, parallel, ggplot2
+Depends: R (>= 3.5), sp, parallel, ggplot2
 Imports: rpivotTable, data.table, tidyverse
 Suggests: WriteXLS, GISTools,
     knitr,


### PR DESCRIPTION
- sysdata.rda won't be read under earlier R versions
- gives a proper error message when people try to install with earlier versions